### PR TITLE
fixed:Flutter app report incident screen drop-down selection bug

### DIFF
--- a/dengue_app/lib/views/report_incident.dart
+++ b/dengue_app/lib/views/report_incident.dart
@@ -478,7 +478,21 @@ class _DistrictDropdownState extends State<DistrictDropdown> {
     return null;
   }
 
-  // todo fix bug on changing already selected dropdowns
+
+  @override
+  void didUpdateWidget(DistrictDropdown oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.selectedProvince != oldWidget.selectedProvince) {
+      setState(() {
+        selectedDistrict = widget.districtList
+            .where((element) => element.provinceId == widget.selectedProvince.id)
+            .toList()
+            .first;
+      });
+    }
+  }
+
+
   @override
   Widget build(BuildContext context) {
     return DropdownButtonFormField<District>(

--- a/dengue_app/lib/views/report_incident.dart
+++ b/dengue_app/lib/views/report_incident.dart
@@ -488,6 +488,7 @@ class _DistrictDropdownState extends State<DistrictDropdown> {
             .where((element) => element.provinceId == widget.selectedProvince.id)
             .toList()
             .first;
+        widget.setDistrictFunction(selectedDistrict);
       });
     }
   }


### PR DESCRIPTION
#32 I have fixed this issue as right now when one item was selected it was clashing with new province so when we update the state I m changing the selectedDistrict to first of the new province

![ezgif com-video-to-gif(1)](https://user-images.githubusercontent.com/52625656/100697524-3f12d880-33bc-11eb-8cad-ce353162f562.gif)
