### PR TITLE
[IMPROVE] Test Modules into Dev Dependencies

### DIFF
--- a/admin_panel/package.json
+++ b/admin_panel/package.json
@@ -3,9 +3,6 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@testing-library/jest-dom": "^4.2.4",
-    "@testing-library/react": "^9.3.2",
-    "@testing-library/user-event": "^7.1.2",
     "axios": "^0.19.2",
     "core-js": "^3",
     "formik": "^2.1.5",
@@ -25,6 +22,11 @@
     "recharts": "^1.8.5",
     "styled-components": "^5.1.1",
     "yup": "^0.29.3"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^4.2.4",
+    "@testing-library/react": "^9.3.2",
+    "@testing-library/user-event": "^7.1.2"
   },
   "scripts": {
     "start": "react-scripts start",


### PR DESCRIPTION
### Changes

Test dependencies including `testing-library` could be moved into `devDependencies` of package.json.

This change makes it even clearer that *dependencies* are required for the main functioning of the app and *devDependencies* are required for building and testing the app.